### PR TITLE
Fix broken twitter links

### DIFF
--- a/src/hyve.twitter.js
+++ b/src/hyve.twitter.js
@@ -85,7 +85,7 @@
                                 'links' : links,
                                 'source' : 'http://twitter.com/'+
                                            item.from_user+
-                                           '/status/'+item.id,
+                                           '/status/'+item.id_str,
                                 'weight' : weight
                             },callback)
                         }
@@ -178,7 +178,7 @@
                             'links' : item.links,
                             'source' : 'http://twitter.com/'+
                                        item.from_user+
-                                       '/status/'+item.id,
+                                       '/status/'+item.id_str,
                             'weight' : item.weight
                         }, callback)
                     }, this)


### PR DESCRIPTION
Majority of twitter source links are broken when using `'id'` over `'id_str'`.  From what I understand `'id_str'` should always be used.

> The act of processing the JSON changes it. The IDs are too large for to-spec Javascript implementations to correctly consume the integer -- the result is a munged integer and the appearance that the IDs do not match. However, when the data was rawly sent from the server, the IDs did in fact match. Use "id_str" at all times to avoid this trap.

-https://dev.twitter.com/discussions/3948
