### PR TITLE
Instagram bug fix and added support for search

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ hyve.feeds.twitter.oauth_consumer_key = 'oauth_consumer_key'
 hyve.feeds.twitter.oauth_signature = 'oauth_signature'
 hyve.feeds.twitter.oauth_nonce = 'oauth_nonce'
 hyve.feeds.twitter.oauth_timestamp = 'oauth_timestamp'
+
+// Instagram (Oauth2)
+hyve.feeds.instagram.access_token = 'access_token'
 ```
 
 ### Commands ###

--- a/src/hyve.instagram.js
+++ b/src/hyve.instagram.js
@@ -1,14 +1,14 @@
 (function(root) {
-
     var hyve = (typeof require == 'function' && !(typeof define == 'function' && define.amd)) ? require('../src/hyve.core.js') : root.hyve
 
     hyve.feeds['instagram'] = {
-        methods : ['friends'],
+        methods : ['friends', 'search'],
         interval : 3000,
         interval_friends : 10000,
         access_token : '',
         feed_urls : {
-            friends: 'https://api.instagram.com/v1/users/self/feed?limit=25&type=post{{ access_token }}{{ since }}{{#&callback=#callback}}'
+            friends: 'https://api.instagram.com/v1/users/self/feed?limit=25&type=post{{ access_token }}{{ since }}{{#&callback=#callback}}',
+            search: 'https://api.instagram.com/v1/tags/{{query}}/media/recent?limit=25&type=post{{ access_token }}{{ since }}{{#&callback=#callback}}'
         },
         format_url : function(query){
             var since_arg = ''
@@ -22,40 +22,43 @@
             }
         },
         parsers : {
-            friends: function(data, query, callback){
-                if (data && data.data && data.data.length > 0){
-                    hyve.feeds.instagram.since = data.data[0].id
-
-                    data.data.forEach(function(item){
-
-                        var text = undefined;
-
-                        if (item.caption) text = item.caption.text
-
-                        hyve.process({
-                            'service' : 'instagram',
-                            'type' : 'image',
-                            'query' : query,
-                            'user' : {
-                                'id' : item.user.id,
-                                'name' : item.user.username,
-                                'real_name' : item.user.full_name,
-                                'avatar' : item.user.profile_picture
-                            },
-                            'id' : item.id,
-                            'date' : item.created_time,
-                            'text' : text,
-                            'thumbnail' : item.images.standard_resolution.url,
-                            'comments' : item.comments.count,
-                            'source' : item.link,
-                            'likes' : item.likes.count,
-                            'weight' : item.likes.count + item.comments.count
-                        },callback)
-
-                    },this)
-                }
-            }
+            search: parseData,
+            friends: parseData
         }
     }
+
+function parseData(data, query, callback){
+    if (data && data.data && data.data.length > 0){
+        hyve.feeds.instagram.since = data.pagination.next_min_id
+
+        data.data.forEach(function(item){
+
+            var text = undefined;
+
+            if (item.caption) text = item.caption.text
+
+            hyve.process({
+                'service' : 'instagram',
+                'type' : 'image',
+                'query' : query,
+                'user' : {
+                    'id' : item.user.id,
+                    'name' : item.user.username,
+                    'real_name' : item.user.full_name,
+                    'avatar' : item.user.profile_picture
+                },
+                'id' : item.id,
+                'date' : item.created_time,
+                'text' : text,
+                'thumbnail' : item.images.standard_resolution.url,
+                'comments' : item.comments.count,
+                'source' : item.link,
+                'likes' : item.likes.count,
+                'weight' : item.likes.count + item.comments.count
+            },callback)
+
+        },this)
+    }
+}
 
 })(this)


### PR DESCRIPTION
- Added support for Instagram searching.(I want to see that in tawlk!)
- Tweaked readme to include info about instagram oauth.
- Fixed handling of duplicates by changing
  https://github.com/Tawlk/hyve/blob/develop/src/hyve.instagram.js#L27R1 to
  https://github.com/DivisibleZero/hyve/pull/new/instagram-searching#L1R32
  making use of the instagram pagination data.
   Items are not sorted by id, but by the time the tag is added to the picture, which was causing problems.

https://github.com/Tawlk/hyve/blob/develop/src/hyve.instagram.js#L27
